### PR TITLE
Throw error if number is bigger than MAX size

### DIFF
--- a/src/toWords.js
+++ b/src/toWords.js
@@ -32,7 +32,12 @@ var TENTHS_LESS_THAN_HUNDRED = [
 function toWords(number, asOrdinal) {
     var words;
     var num = parseInt(number, 10);
-    if (!isFinite(num)) throw new TypeError('Not a finite number: ' + number + ' (' + typeof number + ')');
+    if (!isFinite(num)) {
+        throw new TypeError('Not a finite number: ' + number + ' (' + typeof number + ')');
+    }
+    if (num > MAX) {
+        throw new Error('The number is greater than the MAX size');
+    }
     words = generateWords(num);
     return asOrdinal ? makeOrdinal(words) : words;
 }


### PR DESCRIPTION
The function toWords throws "RangeError: Maximum call stack size exceeded" exception
if the number is greater than MAX size.

The changes from this patch introduce a check to verify if the number can be transformed into words.
If the number is greater than MAX size, it throws an explicit exception to pinpoint the problem.